### PR TITLE
Добавлены подготовительные изменения

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>ru.incube</groupId>
-    <artifactId>lite</artifactId>
+    <artifactId>Lite</artifactId>
     <version>1.0</version>
     <packaging>jar</packaging>
 

--- a/src/main/java/ru/incube/lite/battlepass/database/BattlePassDatabase.java
+++ b/src/main/java/ru/incube/lite/battlepass/database/BattlePassDatabase.java
@@ -87,6 +87,7 @@ public class BattlePassDatabase {
                     + "player_name VARCHAR(64),"
                     + "isPaid BOOLEAN,"
                     + "experience INT,"
+                    + "expToNextLevel INT,"
                     + "freeBattlePassLevel INT,"
                     + "paidBattlePassLevel INT,"
                     + "freeAwardsCollected INT,"
@@ -124,7 +125,7 @@ public class BattlePassDatabase {
             }
 
             // Игрок начинает с первого уровня бесплатного БП
-            String insertPlayerSQL = "INSERT INTO " + TABLE + " (uuid, player_name, isPaid, experience, freeBattlePassLevel, paidBattlePassLevel, freeAwardsCollected, paidAwardsCollected) VALUES (?,?, false, 0, 1, 0, 0, 0);";
+            String insertPlayerSQL = "INSERT INTO " + TABLE + " (uuid, player_name, isPaid, experience, expToNextLevel, freeBattlePassLevel, paidBattlePassLevel, freeAwardsCollected, paidAwardsCollected) VALUES (?,?, false, 0, 0, 1, 0, 0, 0);";
             try (PreparedStatement statement = connection.prepareStatement(insertPlayerSQL)) {
                 statement.setString(1, player.getUniqueId().toString());
                 statement.setString(2, player.getName());
@@ -247,6 +248,55 @@ public class BattlePassDatabase {
                 }
             } catch (SQLException e) {
                 Main.log.severe(String.format("[%s] Ошибка получения опыта игрока %s: " + e.getMessage(), Main.plugin.getDescription().getName(), player.getName()));
+                return 0;
+            }
+        });
+    }
+
+    /**
+     * Установить количество опыта до следующего уровня игроку
+     * Опыт до следующего уровня не может быть меньше 0
+     *
+     * @param player         Игрок
+     * @param expToNextLevel Опыт до следующего уровня
+     * @return CompletableFuture Установка опыта до следующего уровня
+     */
+    public CompletableFuture<Void> setExpToNextLevel(Player player, int expToNextLevel) {
+        return CompletableFuture.runAsync(() -> {
+            UUID uuid = player.getUniqueId();
+            String setExpToNextLevelSQL = "UPDATE " + TABLE + " SET expToNextLevel = ? WHERE uuid = ?;";
+            try (PreparedStatement statement = connection.prepareStatement(setExpToNextLevelSQL)) {
+                statement.setInt(1, Math.max(expToNextLevel, 0));
+                statement.setString(2, uuid.toString());
+                statement.executeUpdate();
+            } catch (SQLException e) {
+                Main.log.severe(String.format("[%s] Ошибка установки опыта до следующего уровня игроку %s: " + e.getMessage(), Main.plugin.getDescription().getName(), player.getName()));
+            }
+        });
+    }
+
+    /**
+     * Получить количество опыта до следующего уровня игрока
+     *
+     * @param player Игрок
+     * @return CompletableFuture Получение опыта до следующего уровня
+     */
+    public CompletableFuture<Integer> getExpToNextLevel(Player player) {
+        return CompletableFuture.supplyAsync(() -> {
+            UUID uuid = player.getUniqueId();
+            String getExpToNextLevelSQL = "SELECT expToNextLevel FROM " + TABLE + " WHERE uuid = ?;";
+            try (PreparedStatement statement = connection.prepareStatement(getExpToNextLevelSQL)) {
+                statement.setString(1, uuid.toString());
+                ResultSet resultSet = statement.executeQuery();
+
+                if (resultSet.next()) {
+                    return resultSet.getInt("expToNextLevel");
+                } else {
+                    Main.log.warning(String.format("[%s] Игрок %s не найден в базе данных", Main.plugin.getDescription().getName(), player.getName()));
+                    return 0;
+                }
+            } catch (SQLException e) {
+                Main.log.severe(String.format("[%s] Ошибка получения опыта до следующего уровня игрока %s: " + e.getMessage(), Main.plugin.getDescription().getName(), player.getName()));
                 return 0;
             }
         });
@@ -478,6 +528,7 @@ public class BattlePassDatabase {
             player.sendMessage("Данные об игроке " + player.getName() + ":");
             player.sendMessage("Платный ли БП: " + ChatColor.GREEN + isPaid(player).join());
             player.sendMessage("Опыт: " + ChatColor.GREEN + getExperience(player).join());
+            player.sendMessage("Опыт до следующего уровня: " + ChatColor.GREEN + getExpToNextLevel(player).join());
             player.sendMessage("Уровень бесплатного БП: " + ChatColor.GREEN + getFreeLevel(player).join());
             player.sendMessage("Уровень платного БП: " + ChatColor.GREEN + getPaidLevel(player).join());
             player.sendMessage("Количество собранных наград бесплатного БП: " + ChatColor.GREEN + getFreeAwardsCollected(player).join());

--- a/src/main/java/ru/incube/lite/battlepass/database/BattlePassDatabase.java
+++ b/src/main/java/ru/incube/lite/battlepass/database/BattlePassDatabase.java
@@ -261,7 +261,7 @@ public class BattlePassDatabase {
      * @param expToNextLevel Опыт до следующего уровня
      * @return CompletableFuture Установка опыта до следующего уровня
      */
-    public CompletableFuture<Void> setExpToNextLevel(Player player, int expToNextLevel) {
+    public CompletableFuture<Void> setExperienceToNextLevel(Player player, int expToNextLevel) {
         return CompletableFuture.runAsync(() -> {
             UUID uuid = player.getUniqueId();
             String setExpToNextLevelSQL = "UPDATE " + TABLE + " SET expToNextLevel = ? WHERE uuid = ?;";
@@ -281,7 +281,7 @@ public class BattlePassDatabase {
      * @param player Игрок
      * @return CompletableFuture Получение опыта до следующего уровня
      */
-    public CompletableFuture<Integer> getExpToNextLevel(Player player) {
+    public CompletableFuture<Integer> getExperienceToNextLevel(Player player) {
         return CompletableFuture.supplyAsync(() -> {
             UUID uuid = player.getUniqueId();
             String getExpToNextLevelSQL = "SELECT expToNextLevel FROM " + TABLE + " WHERE uuid = ?;";
@@ -528,7 +528,7 @@ public class BattlePassDatabase {
             player.sendMessage("Данные об игроке " + player.getName() + ":");
             player.sendMessage("Платный ли БП: " + ChatColor.GREEN + isPaid(player).join());
             player.sendMessage("Опыт: " + ChatColor.GREEN + getExperience(player).join());
-            player.sendMessage("Опыт до следующего уровня: " + ChatColor.GREEN + getExpToNextLevel(player).join());
+            player.sendMessage("Опыт до следующего уровня: " + ChatColor.GREEN + getExperienceToNextLevel(player).join());
             player.sendMessage("Уровень бесплатного БП: " + ChatColor.GREEN + getFreeLevel(player).join());
             player.sendMessage("Уровень платного БП: " + ChatColor.GREEN + getPaidLevel(player).join());
             player.sendMessage("Количество собранных наград бесплатного БП: " + ChatColor.GREEN + getFreeAwardsCollected(player).join());

--- a/src/main/java/ru/incube/lite/battlepass/utils/SkullCreator.java
+++ b/src/main/java/ru/incube/lite/battlepass/utils/SkullCreator.java
@@ -1,0 +1,88 @@
+package ru.incube.lite.battlepass.utils;
+
+import com.destroystokyo.paper.profile.PlayerProfile;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.profile.PlayerTextures;
+
+import java.net.URL;
+import java.util.UUID;
+
+public class SkullCreator {
+    /**
+     * Создать голову игрока
+     *
+     * @return ItemStack черепа игрока
+     */
+    public static ItemStack createSkull() {
+        try {
+            return new ItemStack(Material.valueOf("PLAYER_HEAD"));
+        } catch (IllegalArgumentException e) {
+            return new ItemStack(Material.valueOf("SKULL_ITEM"), 1);
+        }
+    }
+
+    /**
+     * Создать голову игрока используя UUID игрока
+     *
+     * @param id UUID игрока
+     * @return ItemStack голова игрока
+     */
+    public static ItemStack itemFromUuid(UUID id) {
+        return itemWithUuid(createSkull(), id);
+    }
+
+    /**
+     * Переписать UUID головы игрока на новый UUID
+     *
+     * @param item ItemStack головы игрока
+     * @param id   UUID игрока
+     * @return ItemStack голова игрока
+     */
+    public static ItemStack itemWithUuid(ItemStack item, UUID id) {
+        SkullMeta meta = (SkullMeta) item.getItemMeta();
+        meta.setOwningPlayer(Bukkit.getOfflinePlayer(id));
+        item.setItemMeta(meta);
+
+        return item;
+    }
+
+    /**
+     * Получить голову игрока из скина
+     *
+     * @param url Ссылка на скин
+     * @return Голова игрока
+     */
+    public static ItemStack createHead(URL url) {
+        UUID uuid = UUID.randomUUID();
+        PlayerProfile profile = Bukkit.createProfile(uuid);
+
+        PlayerTextures textures = profile.getTextures();
+        textures.setSkin(url);
+
+        profile.setTextures(textures);
+
+        ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+        SkullMeta skullMeta = (SkullMeta) head.getItemMeta();
+        skullMeta.setPlayerProfile(profile);
+
+        return head;
+    }
+
+    /**
+     * Получить голову игрока из экземпляра игрока
+     *
+     * @param player Игрок, чью голову нужно получить
+     * @return Голова игрока
+     */
+    public static ItemStack createHead(Player player) {
+        ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+        SkullMeta skullMeta = (SkullMeta) head.getItemMeta();
+        skullMeta.setOwningPlayer(player);
+
+        return head;
+    }
+}


### PR DESCRIPTION
Идею делать GUI БаттлПасса на обычных инвентарях недавно отменили. 
Но работа, которая была сделана до отмены, не будет лишней. 
Из изменений:
1. Добавлен новый параметр "_expToNextLevel_" - количество опыта до следующего уровня БП.
2. Добавлен генератор голов игроков. 
3. Изменены названия методов для удобного использования и понимания:
    - `#setExpToNextLevel` -> `#setExperienceToNextLevel`
    - `#getExpToNextLevel` -> `#getExperienceToNextLevel`